### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An interactive 3D globe application that provides AI-powered insights, videos, a
 - **Location Search**: Find any place on Earth with intelligent search
 - **History Tracking**: Keep track of previously explored locations
 - **Mobile Responsive**: Works seamlessly on desktop and mobile devices
+- **Light/Dark Mode Toggle**: Switch between light and dark themes
 
 ## 🛠️ Technology Stack
 

--- a/static/main.css
+++ b/static/main.css
@@ -42,6 +42,25 @@
     --add-info-button-text-color: white;
 }
 
+body.light-mode {
+    --panel-bg-gradient-start: rgba(240, 240, 240, 0.97);
+    --panel-bg-gradient-end: rgba(225, 225, 225, 0.97);
+    --panel-border-color: rgba(0, 0, 0, 0.15);
+    --text-primary: #000000;
+    --text-secondary: #222222;
+    --text-tertiary: #555555;
+    --accent-color: #007bff;
+}
+
+body.light-mode #map_rotate_btns {
+    background-color: #f0f0f0;
+}
+
+body.light-mode .map_rotate_btn {
+    background-color: #ffffff;
+    color: #000000;
+}
+
 /* Base font sizes for different screen sizes */
 @media (min-width: 1200px) {
     :root {

--- a/static/main.js
+++ b/static/main.js
@@ -689,9 +689,32 @@ document.addEventListener('DOMContentLoaded', (event) => {
     const tutorialModal = document.getElementById('tutorialModal');
     const tutorialOverlay = document.getElementById('tutorialOverlay');
     const closeTutorialButton = document.getElementById('closeTutorial');
-    const sidePanel = document.getElementById('side-panel'); 
-    const hidePanelButton = document.getElementById('hidePanelButton'); 
+    const sidePanel = document.getElementById('side-panel');
+    const hidePanelButton = document.getElementById('hidePanelButton');
     const showPanelButton = document.getElementById('showPanelButton');
+    const themeToggleBtn = document.getElementById('themeToggle');
+
+    function applyTheme(theme) {
+        if (theme === 'light') {
+            document.body.classList.add('light-mode');
+            if (themeToggleBtn) themeToggleBtn.innerHTML = '<i class="fas fa-moon"></i>';
+        } else {
+            document.body.classList.remove('light-mode');
+            if (themeToggleBtn) themeToggleBtn.innerHTML = '<i class="fas fa-sun"></i>';
+        }
+    }
+
+    const savedTheme = localStorage.getItem('theme');
+    applyTheme(savedTheme);
+
+    if (themeToggleBtn) {
+        themeToggleBtn.addEventListener('click', () => {
+            const isLight = document.body.classList.contains('light-mode');
+            const newTheme = isLight ? 'dark' : 'light';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+        });
+    }
 
     // Check if the user has visited before
     if (!localStorage.getItem('hasVisitedEarthSearch')) {

--- a/templates/main.html
+++ b/templates/main.html
@@ -41,6 +41,9 @@
             <button id="randomButton" class="map_rotate_btn" title="Show Random Location" enabled>
                 <i class="fas fa-random"></i>
             </button>
+            <button id="themeToggle" class="map_rotate_btn" title="Toggle Light/Dark Mode">
+                <i class="fas fa-sun"></i>
+            </button>
         </div>
     
         <div id="side-panel" class="side-panel">


### PR DESCRIPTION
## Summary
- add a theme toggle button in the UI
- allow toggling light and dark modes via JS and local storage
- style the light mode via CSS variables
- document new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844975d2934832682671a0d4061626a